### PR TITLE
Update README.md for S3 sink

### DIFF
--- a/data-prepper-plugins/s3-sink/README.md
+++ b/data-prepper-plugins/s3-sink/README.md
@@ -18,10 +18,9 @@ pipeline:
           sts_role_arn: arn:aws:iam::123456789012:role/Data-Prepper
           sts_header_overrides:
         max_retries: 5
-        bucket:
-          name: bucket_name
-          object_key:
-            path_prefix: my-elb/%{yyyy}/%{MM}/%{dd}/
+        bucket: bucket_name
+        object_key:
+          path_prefix: my-elb/%{yyyy}/%{MM}/%{dd}/
         threshold:
           event_count: 2000
           maximum_size: 50mb
@@ -41,7 +40,7 @@ pipeline:
 
 - `max_retries` (Optional) : An integer value indicates the maximum number of times that single request should be retired in-order to ingest data to amazon s3. Defaults to `5`.
 
-- `bucket` (Required) : Object storage built to store and retrieve any amount of data from anywhere, User must provide bucket name.
+- `bucket` (Required) : The name of the S3 bucket to write to.
 
 - `object_key` (Optional) : It contains `path_prefix` and `file_pattern`. Defaults to s3 object `events-%{yyyy-MM-dd'T'hh-mm-ss}` inside bucket root directory.
 


### PR DESCRIPTION
### Description
The S3 sink configuration in the README is not correct. This PR fixes that configuration.
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has been documented.
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
